### PR TITLE
Update grant_change_permission.ps1 (Brief description max length of 80)

### DIFF
--- a/grant_change_permission.ps1
+++ b/grant_change_permission.ps1
@@ -95,8 +95,14 @@ function New-TOPdeskChange {
     }
 
     if ($changeObject.BriefDescription) {
+        if($changeObject.BriefDescription.Lenth -gt 80){
+            $i = $changeObject.BriefDescription.Lenth - 80
+            $BriefDescription = $changeObject.BriefDescription.SubString($i,80)
+        }else{
+            $BriefDescription = $changeObject.BriefDescription
+        }
         $requestObject += @{
-            briefDescription = $changeObject.BriefDescription
+            briefDescription = $BriefDescription
         }
         Write-Verbose -Verbose -Message "Added brief description $($changeObject.BriefDescription) to request"
     }

--- a/grant_change_permission.ps1
+++ b/grant_change_permission.ps1
@@ -96,8 +96,7 @@ function New-TOPdeskChange {
 
     if ($changeObject.BriefDescription) {
         if($changeObject.BriefDescription.Lenth -gt 80){
-            $i = $changeObject.BriefDescription.Lenth - 80
-            $BriefDescription = $changeObject.BriefDescription.SubString($i,80)
+            $BriefDescription = $changeObject.BriefDescription.SubString(0,80)
         }else{
             $BriefDescription = $changeObject.BriefDescription
         }


### PR DESCRIPTION
On line 98 to 106 I changed the brief description. There is a limit to the length of 80. If that limit is reached it gives an error.  In this example the first characters of the string are removed.