### PR TITLE
Update revoke_change_permission.ps1 (brief description max 80 char

### DIFF
--- a/revoke_change_permission.ps1
+++ b/revoke_change_permission.ps1
@@ -95,8 +95,11 @@ function New-TOPdeskChange {
     }
 
     if ($changeObject.BriefDescription) {
-        $requestObject += @{
-            briefDescription = $changeObject.BriefDescription
+        if($changeObject.BriefDescription.Lenth -gt 80){
+            $i = $changeObject.BriefDescription.Lenth - 80
+            $BriefDescription = $changeObject.BriefDescription.SubString($i,80)
+        }else{
+            $BriefDescription = $changeObject.BriefDescription
         }
         Write-Verbose -Verbose -Message "Added brief description $($changeObject.BriefDescription) to request"
     }


### PR DESCRIPTION
On line 98 to 106 I changed the brief description. There is a limit to the length of 80. If that limit is reached it gives an error.  In this example the first characters of the string are removed.